### PR TITLE
fix: set manager immediately on component registration

### DIFF
--- a/changelog/48.breaking.0.rst
+++ b/changelog/48.breaking.0.rst
@@ -1,0 +1,1 @@
+:meth:`RichComponent.get_manager` and :meth:`RichComponent.set_manager` are now class methods.

--- a/changelog/48.breaking.1.rst
+++ b/changelog/48.breaking.1.rst
@@ -1,0 +1,2 @@
+:meth:`ComponentManager.register_component` and :meth:`ComponentManager.deregister_component` have been modified, and certain internal behaviour has changed.
+More noticeably, :meth:`ComponentManager.deregister_component` now takes a component identifier rather than a full class.

--- a/changelog/48.feature.rst
+++ b/changelog/48.feature.rst
@@ -1,0 +1,2 @@
+The :class:`ComponentManager` instance is now immediately stored on a :class:`RichComponent` when it is registered.
+This should reduce the number of times you need to manually provide a manager to :meth:`RichComponent.as_ui_component` etc.

--- a/src/disnake_compass/api/component.py
+++ b/src/disnake_compass/api/component.py
@@ -264,6 +264,8 @@ class ComponentManager(typing.Protocol):
         self,
         component_type: type[ComponentT],
         /,
+        *,
+        identifier: str,
     ) -> type[ComponentT]:
         r"""Register a component to this component manager.
 
@@ -274,7 +276,9 @@ class ComponentManager(typing.Protocol):
         ----------
         component_type
             The component class to register.
-
+        identifier
+            The identifier with which to register this component class.
+            
         Returns
         -------
         :class:`type`\[:data:`.ComponentT`]
@@ -283,7 +287,7 @@ class ComponentManager(typing.Protocol):
         """
         ...
 
-    def deregister_component(self, component_type: type[RichComponent], /) -> None:
+    def deregister_component(self, identifier: str, /) -> None:
         """Deregister a component from this component manager.
 
         After deregistration, the component will no be tracked, and its
@@ -291,8 +295,8 @@ class ComponentManager(typing.Protocol):
 
         Parameters
         ----------
-        component_type
-            The component class to deregister.
+        identifier
+            The identifier of the component class to deregister.
 
         Returns
         -------

--- a/src/disnake_compass/api/component.py
+++ b/src/disnake_compass/api/component.py
@@ -40,11 +40,13 @@ class RichComponent(typing.Protocol):
 
     __slots__: typing.Sequence[str] = ()
 
-    def get_manager(self) -> ComponentManager:
+    @classmethod
+    def get_manager(cls) -> ComponentManager:
         """Get the manager that was responsible for parsing this component instance."""
         ...
 
-    def set_manager(self, manager: ComponentManager, /) -> None:
+    @classmethod
+    def set_manager(cls, manager: ComponentManager | None, /) -> None:
         """Set the manager that was responsible for parsing this component instance."""
         ...
 

--- a/src/disnake_compass/impl/component/base.py
+++ b/src/disnake_compass/impl/component/base.py
@@ -208,17 +208,23 @@ class ComponentBase(component_api.RichComponent, typing.Protocol, metaclass=Comp
     """Overarching base class for any kind of component."""
 
     _factory: typing.ClassVar[component_api.ComponentFactory[typing_extensions.Self]]
-    _manager: component_api.ComponentManager = fields.meta()
+    _manager: typing.ClassVar[component_api.ComponentManager | None] = None
 
-    def get_manager(self) -> component_api.ComponentManager:  # noqa: D102
+    @classmethod
+    def get_manager(cls) -> component_api.ComponentManager:  # noqa: D102
         # <<Docstring inherited from component_api.RichComponent>>
 
-        return self._manager
+        if cls._manager is None:
+            msg = f"Component {cls.__qualname__} is not yet registered to a manager."
+            raise RuntimeError(msg)
 
-    def set_manager(self, manager: component_api.ComponentManager) -> None:  # noqa: D102
+        return cls._manager
+
+    @classmethod
+    def set_manager(cls, manager: component_api.ComponentManager | None) -> None:  # noqa: D102
         # <<Docstring inherited from component_api.RichComponent>>
 
-        self._manager = manager
+        cls._manager = manager
 
     @classmethod
     def get_factory(cls) -> component_api.ComponentFactory[typing_extensions.Self]:


### PR DESCRIPTION
This PR makes it so that the registering component manager is immediately stored on the component class.
This reduces the amount of times you manually have to provide a manager when working with component classes/instances.

# Breaking changes:
- `RichComponent.get_manager`/`RichComponent.set_manager` are now class methods,
- `ComponentManager.deregister_component` now takes a component identifier (string) instead of a class,
- Some further internal logic changes.